### PR TITLE
drop qemu cleanup job

### DIFF
--- a/kiwi_crossprepare_plugin/tasks/system_crossprepare.py
+++ b/kiwi_crossprepare_plugin/tasks/system_crossprepare.py
@@ -124,10 +124,6 @@ class SystemCrossprepareTask(CliTask):
             log.info(f'--> {qemu_binary}')
             shutil.copy(qemu_binary, target_bin_dir)
 
-        # Write files to exclude as metadata for kiwi
-        with open(target_image_dir + '/exclude_files.yaml', 'w') as exclude:
-            yaml.dump({'exclude': qemu_binaries}, exclude)
-
         # Call init binary
         log.info(f'Calling init binary {init_binary!r}')
         Command.run([init_binary])


### PR DESCRIPTION
This must be done later (currently in editbootinstall) or later jobs
like building the initrd will fail.